### PR TITLE
Take over min-max runtime feature and add a specific deadline for each appliance

### DIFF
--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -237,13 +237,26 @@ blueprint:
 
         **[NOTE]**
 
-        - If your solar system is not coupled with a battery, leave this field empty
+        - If your solar system is not coupled with a battery or if you are not enforcing a minimum appliance run time, leave this field empty
       default:
       selector:
         entity:
           domain: sensor
           multiple: false
 
+    time_of_sunset:
+      name: "The time of sunset at the current location "
+      description: >
+        The time of sunset in the current location. You can use `sensor.sun_next_setting`.
+
+        **[NOTE]**
+
+        - This MUST be set if Appliance minimum daily runtime is set.
+      default:
+      selector:
+        entity:
+          domain: sensor
+          multiple: false
 
     appliance_switch:
       name: "Appliance Entity"
@@ -287,6 +300,54 @@ blueprint:
       default: False
       selector:
         boolean:
+
+    appliance_minimum_run_time:
+      name: "Appliance minimum daily runtime"
+      description: > 
+        Enforces that an appliance runs a minimum time every day. Useful for things such as pool pumps.
+
+        Behavior is as follows: 
+
+        - During the day, if remaining daily solar production forecast says there will be enough power to run the appliance, wait
+        
+        - If remaining solar forecast is not enough to meet minimum runtime, turn on the appliance whenever there is some excess power
+        
+        - If the remaining minimum runtime is greater than the remaining time till the deadline, turn on the device. 
+
+        **[NOTE]**
+        
+        - For this to work correctly, you must configure the time_of_sunset and solar_production_forecast fields 
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 1440
+          step: 1
+          unit_of_measurement: min
+
+    appliance_maximum_run_time:
+      name: "Appliance maximum daily runtime"
+      description: "Limits the maximum time the appliance should run in a day.\n0 means infinite time. This value must be greater than minimum runtime."
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 1440
+          step: 1
+          unit_of_measurement: min
+
+    appliance_runtime_deadline:
+      name: "Appliance Runtime Deadline"
+      description: >
+        The latest time by which the appliance must have completed its minimum runtime.
+        If not set, midnight (23:59) will be used as default.
+
+        **Example:** If you set `22:30:00`, the automation will ensure that the appliance
+        has met its minimum runtime by 22:30.
+      default: "23:59:00"
+      selector:
+        time:
+
 
     dynamic_current_appliance:
       name: "Dynamic current control"
@@ -425,4 +486,8 @@ action:
       import_export_power: !input import_export_power
       home_battery_capacity: !input home_battery_capacity
       solar_production_forecast: !input solar_production_forecast
+      time_of_sunset: !input time_of_sunset
       appliance_once_only: !input appliance_once_only
+      appliance_maximum_run_time: !input appliance_maximum_run_time
+      appliance_minimum_run_time: !input appliance_minimum_run_time
+      appliance_runtime_deadline: !input appliance_runtime_deadline


### PR DESCRIPTION
This PR takes over the min/max feature from the side branch towards EventoCasas mainbranch: https://github.com/InventoCasa/ha-advanced-blueprints/pull/80

And adds on top a feature which allows a specific deadline to meet the min/max runtime for each appliance