### PR TITLE
Adjust min_excess_power and add min_pv_power logic

### DIFF
--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -208,6 +208,53 @@ blueprint:
                 - sensor
               multiple: false
               reorder: false
+              
+        min_pv_power:
+          name: Minimum PV Power threshold
+          description:
+            "Minimum PV production (in watts) required before the script considers
+            solar as 'active'. Below this threshold, appliances will be switched off
+            even if your battery is keeping the grid balance near zero.
+
+            Recommended: 50W. Set to 0 to disable this behavior.
+
+            **[NOTE]**
+
+            - **This value must be the same for all your created automations based on
+            this blueprint!**
+            "
+          default: 50
+          selector:
+            number:
+              min: 0.0
+              max: 500.0
+              step: 10.0
+              unit_of_measurement: W
+              mode: slider
+              
+        min_excess_power:
+          name: Minimum excess power
+          description:
+            "Minimum excess power (in watts) that must be available before keeping
+            an appliance running. Should be slightly negative to compensate for
+            inaccurate power corrections.
+
+            **[WARNING]**
+
+            - Do not set this above 0, otherwise dynamic current appliances may be
+            abruptly switched off in some situations.
+
+            - **This value must be the same for all your created automations based on
+            this blueprint!**
+            "
+          default: -10
+          selector:
+            number:
+              min: -200.0
+              max: 0.0
+              step: 5.0
+              unit_of_measurement: W
+              mode: slider
 
     home_battery_settings:
       name: Home Battery Settings
@@ -912,3 +959,5 @@ action:
       appliance_minimum_run_time: !input appliance_minimum_run_time
       appliance_runtime_deadline: !input appliance_runtime_deadline
       enabled: !input enabled
+      min_pv_power: !input min_pv_power
+      min_excess_power: !input min_excess_power

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -293,6 +293,8 @@ def pv_excess_control(
     appliance_minimum_run_time,
     appliance_runtime_deadline,
     enabled,
+    min_pv_power,
+    min_excess_power,
 ):
     automation_id = (
         automation_id[11:] if automation_id[:11] == "automation." else automation_id
@@ -339,14 +341,14 @@ def pv_excess_control(
         appliance_minimum_run_time,
         appliance_runtime_deadline,
         enabled,
+        min_pv_power,
+        min_excess_power,
     )
 
 
 class PvExcessControl:
     # TODO:
     #  - What about other domains than switches? Enable use of other domains (e.g. light, ...)
-    #  - Make min_excess_power configurable via blueprint
-    #  - Make min_pv_power configurable via blueprint (Minimum of solar panels to make
     #  - Implement updating of pv sensors history more often. E.g. every 10secs, and averaging + adding to history every minute.
     instances = {}
     export_power = None
@@ -373,7 +375,7 @@ class PvExcessControl:
     #  NOTE: Should be slightly negative, to compensate for inaccurate power corrections
     #  WARNING: Do net set this to more than 0, otherwise some devices with dynamic current control will abruptly get switched off in some
     #  situations.
-    min_excess_power = -20
+    min_excess_power = -10
     min_pv_power = 50  # Solar Watts. Below this, treat solar as off regardless of battery balance. (In case you cant read Battery level in HA
     on_time_counter = 0
 
@@ -416,6 +418,8 @@ class PvExcessControl:
         appliance_minimum_run_time,
         appliance_runtime_deadline,
         enabled,
+        min_pv_power,
+        min_excess_power,
     ):
         if automation_id not in PvExcessControl.instances:
             inst = self
@@ -442,6 +446,9 @@ class PvExcessControl:
         PvExcessControl.zero_feed_in = bool(zero_feed_in)
         PvExcessControl.zero_feed_in_load = zero_feed_in_load
         PvExcessControl.zero_feed_in_level = float(zero_feed_in_level)
+        
+        PvExcessControl.min_pv_power = float(min_pv_power)
+        PvExcessControl.min_excess_power = float(min_excess_power)
 
         inst.dynamic_current_appliance = bool(dynamic_current_appliance)
         inst.round_target_current = bool(round_target_current)

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -346,6 +346,7 @@ class PvExcessControl:
     # TODO:
     #  - What about other domains than switches? Enable use of other domains (e.g. light, ...)
     #  - Make min_excess_power configurable via blueprint
+    #  - Make min_pv_power configurable via blueprint (Minimum of solar panels to make
     #  - Implement updating of pv sensors history more often. E.g. every 10secs, and averaging + adding to history every minute.
     instances = {}
     export_power = None
@@ -372,7 +373,8 @@ class PvExcessControl:
     #  NOTE: Should be slightly negative, to compensate for inaccurate power corrections
     #  WARNING: Do net set this to more than 0, otherwise some devices with dynamic current control will abruptly get switched off in some
     #  situations.
-    min_excess_power = -10
+    min_excess_power = -20
+    min_pv_power = 50  # Solar Watts. Below this, treat solar as off regardless of battery balance. (In case you cant read Battery level in HA
     on_time_counter = 0
 
     def __init__(
@@ -1230,6 +1232,16 @@ class PvExcessControl:
             log.error(f"Could not update Export/PV history!: {e}")
             return
         else:
+            # Override : If Pv production is neglible, battery is masking grid balance.
+            # Force excess negative so appliances get switched off even if grid reads ~0W.
+            if pv_power_state is not None and pv_power_state < PvExcessControl.min_pv_power:
+                log.debug(
+                    f"PV power ({pv_power_state}W) below min threshold ({PvExcessControl.min_pv_power}W) — "
+                    f"overriding excess_pwr to -9999 to force appliance shutdown."
+                )
+                excess_pwr = -9999
+                export_pwr = 0
+            
             PvExcessControl.export_history_buffer.append(export_pwr)
             PvExcessControl.pv_history_buffer.append(excess_pwr)
             PvExcessControl.load_history_buffer.append(load_pwr)


### PR DESCRIPTION
Updated min_excess_power to -20 and added min_pv_power configuration. Implemented logic to force appliance shutdown if PV power is below the minimum threshold.

For people who's battery is not readable in HA or have other system, look that the solar panels actuallly ARE generating power in order to make sure there is excess SOLAR

say if they use car of a plugin battery thats not HA compatible, it will keep the meter at 0 but this script doesnt doesnt look at it so

just as excess power, it should be a field in  to edit this in the blue. I might add that later